### PR TITLE
chore(stocks): sync Taiwan stock list 2026-02-27

### DIFF
--- a/static/tw_stocks.json
+++ b/static/tw_stocks.json
@@ -5,5047 +5,8830 @@
   "stocks": [
     {
       "id": "0050",
-      "name": "元大台灣50"
+      "name": "元大台灣50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "0051",
-      "name": "元大中型100"
+      "name": "元大中型100",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "0052",
-      "name": "富邦科技"
+      "name": "富邦科技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "0053",
-      "name": "元大電子"
+      "name": "元大電子",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "0055",
-      "name": "元大MSCI金融"
+      "name": "元大MSCI金融",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "0056",
-      "name": "元大高股息"
+      "name": "元大高股息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "0057",
-      "name": "富邦摩台"
+      "name": "富邦摩台",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "0061",
-      "name": "元大寶滬深"
+      "name": "元大寶滬深",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "006203",
-      "name": "元大MSCI台灣"
+      "name": "元大MSCI台灣",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "006204",
-      "name": "永豐臺灣加權"
+      "name": "永豐臺灣加權",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "006205",
-      "name": "富邦上証"
+      "name": "富邦上証",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "006206",
-      "name": "元大上證50"
+      "name": "元大上證50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "006207",
-      "name": "復華滬深"
+      "name": "復華滬深",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "006208",
-      "name": "富邦台50"
+      "name": "富邦台50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00625K",
-      "name": "富邦上証+R"
+      "name": "富邦上証+R",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00631L",
-      "name": "元大台灣50正2"
+      "name": "元大台灣50正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00632R",
-      "name": "元大台灣50反1"
+      "name": "元大台灣50反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00633L",
-      "name": "富邦上証正2"
+      "name": "富邦上証正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00634R",
-      "name": "富邦上証反1"
+      "name": "富邦上証反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00635U",
-      "name": "期元大S&P黃金"
+      "name": "期元大S&P黃金",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00636",
-      "name": "國泰中國A50"
+      "name": "國泰中國A50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00636K",
-      "name": "國泰中國A50+U"
+      "name": "國泰中國A50+U",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00637L",
-      "name": "元大滬深300正2"
+      "name": "元大滬深300正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00638R",
-      "name": "元大滬深300反1"
+      "name": "元大滬深300反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00639",
-      "name": "富邦深100"
+      "name": "富邦深100",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00640L",
-      "name": "富邦日本正2"
+      "name": "富邦日本正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00641R",
-      "name": "富邦日本反1"
+      "name": "富邦日本反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00642U",
-      "name": "期元大S&P石油"
+      "name": "期元大S&P石油",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00643",
-      "name": "群益深証中小"
+      "name": "群益深証中小",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00643K",
-      "name": "群益深証中小+R"
+      "name": "群益深証中小+R",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00645",
-      "name": "富邦日本"
+      "name": "富邦日本",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00646",
-      "name": "元大S&P500"
+      "name": "元大S&P500",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00647L",
-      "name": "元大S&P500正2"
+      "name": "元大S&P500正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00648R",
-      "name": "元大S&P500反1"
+      "name": "元大S&P500反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00650L",
-      "name": "復華香港正2"
+      "name": "復華香港正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00651R",
-      "name": "復華香港反1"
+      "name": "復華香港反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00652",
-      "name": "富邦印度"
+      "name": "富邦印度",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00653L",
-      "name": "富邦印度正2"
+      "name": "富邦印度正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00654R",
-      "name": "富邦印度反1"
+      "name": "富邦印度反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00655L",
-      "name": "國泰中國A50正2"
+      "name": "國泰中國A50正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00656R",
-      "name": "國泰中國A50反1"
+      "name": "國泰中國A50反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00657",
-      "name": "國泰日經225"
+      "name": "國泰日經225",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00657K",
-      "name": "國泰日經225+U"
+      "name": "國泰日經225+U",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00660",
-      "name": "元大歐洲50"
+      "name": "元大歐洲50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00661",
-      "name": "元大日經225"
+      "name": "元大日經225",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00662",
-      "name": "富邦NASDAQ"
+      "name": "富邦NASDAQ",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00663L",
-      "name": "國泰臺灣加權正2"
+      "name": "國泰臺灣加權正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00664R",
-      "name": "國泰臺灣加權反1"
+      "name": "國泰臺灣加權反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00665L",
-      "name": "富邦�琤肭磪囓�2"
+      "name": "富邦�琤肭磪囓�2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00666R",
-      "name": "富邦�琤肭磪齯�1"
+      "name": "富邦�琤肭磪齯�1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00668",
-      "name": "國泰美國道瓊"
+      "name": "國泰美國道瓊",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00668K",
-      "name": "國泰美國道瓊+U"
+      "name": "國泰美國道瓊+U",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00669R",
-      "name": "國泰美國道瓊反1"
+      "name": "國泰美國道瓊反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00670L",
-      "name": "富邦NASDAQ正2"
+      "name": "富邦NASDAQ正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00671R",
-      "name": "富邦NASDAQ反1"
+      "name": "富邦NASDAQ反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00673R",
-      "name": "期元大S&P原油反1"
+      "name": "期元大S&P原油反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00674R",
-      "name": "期元大S&P黃金反1"
+      "name": "期元大S&P黃金反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00675L",
-      "name": "富邦臺灣加權正2"
+      "name": "富邦臺灣加權正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00676R",
-      "name": "富邦臺灣加權反1"
+      "name": "富邦臺灣加權反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00678",
-      "name": "群益那斯達克生技"
+      "name": "群益那斯達克生技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00680L",
-      "name": "元大美債20正2"
+      "name": "元大美債20正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00681R",
-      "name": "元大美債20反1"
+      "name": "元大美債20反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00682U",
-      "name": "期元大美元指數"
+      "name": "期元大美元指數",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00683L",
-      "name": "期元大美元指正2"
+      "name": "期元大美元指正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00684R",
-      "name": "期元大美元指反1"
+      "name": "期元大美元指反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00685L",
-      "name": "群益臺灣加權正2"
+      "name": "群益臺灣加權正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00686R",
-      "name": "群益臺灣加權反1"
+      "name": "群益臺灣加權反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00688L",
-      "name": "國泰20年美債正2"
+      "name": "國泰20年美債正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00689R",
-      "name": "國泰20年美債反1"
+      "name": "國泰20年美債反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00690",
-      "name": "兆豐藍籌30"
+      "name": "兆豐藍籌30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00692",
-      "name": "富邦公司治理"
+      "name": "富邦公司治理",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00693U",
-      "name": "期街口S&P黃豆"
+      "name": "期街口S&P黃豆",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00700",
-      "name": "富邦�琤肭磪�"
+      "name": "富邦�琤肭磪�",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00701",
-      "name": "國泰股利精選30"
+      "name": "國泰股利精選30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00702",
-      "name": "國泰標普低波高息"
+      "name": "國泰標普低波高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00703",
-      "name": "台新MSCI中國"
+      "name": "台新MSCI中國",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00706L",
-      "name": "期元大S&P日圓正2"
+      "name": "期元大S&P日圓正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00707R",
-      "name": "期元大S&P日圓反1"
+      "name": "期元大S&P日圓反1",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00708L",
-      "name": "期元大S&P黃金正2"
+      "name": "期元大S&P黃金正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00709",
-      "name": "富邦歐洲"
+      "name": "富邦歐洲",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00710B",
-      "name": "復華彭博非投等債"
+      "name": "復華彭博非投等債",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00711B",
-      "name": "復華彭博新興債"
+      "name": "復華彭博新興債",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00712",
-      "name": "復華富時不動產"
+      "name": "復華富時不動產",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00713",
-      "name": "元大台灣高息低波"
+      "name": "元大台灣高息低波",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00714",
-      "name": "群益道瓊美國地產"
+      "name": "群益道瓊美國地產",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00715L",
-      "name": "期街口S&P布蘭特油正2"
+      "name": "期街口S&P布蘭特油正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00717",
-      "name": "富邦美國特別股"
+      "name": "富邦美國特別股",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00728",
-      "name": "第一金工業30"
+      "name": "第一金工業30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00730",
-      "name": "富邦臺灣優質高息"
+      "name": "富邦臺灣優質高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00731",
-      "name": "復華富時高息低波"
+      "name": "復華富時高息低波",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00733",
-      "name": "富邦臺灣中小"
+      "name": "富邦臺灣中小",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00735",
-      "name": "國泰臺韓科技"
+      "name": "國泰臺韓科技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00736",
-      "name": "國泰新興市場"
+      "name": "國泰新興市場",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00737",
-      "name": "國泰AI機器人"
+      "name": "國泰AI機器人",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00738U",
-      "name": "期元大道瓊白銀"
+      "name": "期元大道瓊白銀",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00739",
-      "name": "元大MSCI A股"
+      "name": "元大MSCI A股",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00752",
-      "name": "中信中國50"
+      "name": "中信中國50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00753L",
-      "name": "中信中國50正2"
+      "name": "中信中國50正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00757",
-      "name": "統一FANG+"
+      "name": "統一FANG+",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00762",
-      "name": "元大全球AI"
+      "name": "元大全球AI",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00763U",
-      "name": "期街口道瓊銅"
+      "name": "期街口道瓊銅",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00770",
-      "name": "國泰北美科技"
+      "name": "國泰北美科技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00771",
-      "name": "元大US高息特別股"
+      "name": "元大US高息特別股",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00775B",
-      "name": "新光投等債15+"
+      "name": "新光投等債15+",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00783",
-      "name": "富邦中証500"
+      "name": "富邦中証500",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00830",
-      "name": "國泰費城半導體"
+      "name": "國泰費城半導體",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00850",
-      "name": "元大臺灣ESG永續"
+      "name": "元大臺灣ESG永續",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00851",
-      "name": "台新全球AI"
+      "name": "台新全球AI",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00852L",
-      "name": "國泰美國道瓊正2"
+      "name": "國泰美國道瓊正2",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00861",
-      "name": "元大全球未來通訊"
+      "name": "元大全球未來通訊",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00865B",
-      "name": "國泰US短期公債"
+      "name": "國泰US短期公債",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00875",
-      "name": "國泰網路資安"
+      "name": "國泰網路資安",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00876",
-      "name": "元大全球5G"
+      "name": "元大全球5G",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00878",
-      "name": "國泰永續高股息"
+      "name": "國泰永續高股息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00881",
-      "name": "國泰台灣科技龍頭"
+      "name": "國泰台灣科技龍頭",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00882",
-      "name": "中信中國高股息"
+      "name": "中信中國高股息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00885",
-      "name": "富邦越南"
+      "name": "富邦越南",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00891",
-      "name": "中信關鍵半導體"
+      "name": "中信關鍵半導體",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00892",
-      "name": "富邦台灣半導體"
+      "name": "富邦台灣半導體",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00893",
-      "name": "國泰智能電動車"
+      "name": "國泰智能電動車",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00894",
-      "name": "中信小資高價30"
+      "name": "中信小資高價30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00895",
-      "name": "富邦未來車"
+      "name": "富邦未來車",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00896",
-      "name": "中信綠能及電動車"
+      "name": "中信綠能及電動車",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00897",
-      "name": "富邦基因免疫生技"
+      "name": "富邦基因免疫生技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00898",
-      "name": "國泰基因免疫革命"
+      "name": "國泰基因免疫革命",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00899",
-      "name": "FT潔淨能源"
+      "name": "FT潔淨能源",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00900",
-      "name": "富邦特選高股息30"
+      "name": "富邦特選高股息30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00901",
-      "name": "永豐智能車供應鏈"
+      "name": "永豐智能車供應鏈",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00902",
-      "name": "中信電池及儲能"
+      "name": "中信電池及儲能",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00903",
-      "name": "富邦元宇宙"
+      "name": "富邦元宇宙",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00904",
-      "name": "新光臺灣半導體30"
+      "name": "新光臺灣半導體30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00905",
-      "name": "FT臺灣SMART"
+      "name": "FT臺灣SMART",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00907",
-      "name": "永豐優息存股"
+      "name": "永豐優息存股",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00908",
-      "name": "富邦入息REITs+"
+      "name": "富邦入息REITs+",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00909",
-      "name": "國泰數位支付服務"
+      "name": "國泰數位支付服務",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00910",
-      "name": "第一金太空衛星"
+      "name": "第一金太空衛星",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00911",
-      "name": "兆豐洲際半導體"
+      "name": "兆豐洲際半導體",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00912",
-      "name": "中信臺灣智慧50"
+      "name": "中信臺灣智慧50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00913",
-      "name": "兆豐台灣晶圓製造"
+      "name": "兆豐台灣晶圓製造",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00915",
-      "name": "凱基優選高股息30"
+      "name": "凱基優選高股息30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00916",
-      "name": "國泰全球品牌50"
+      "name": "國泰全球品牌50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00917",
-      "name": "中信特選金融"
+      "name": "中信特選金融",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00918",
-      "name": "大華優利高填息30"
+      "name": "大華優利高填息30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00919",
-      "name": "群益台灣精選高息"
+      "name": "群益台灣精選高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00920",
-      "name": "富邦ESG綠色電力"
+      "name": "富邦ESG綠色電力",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00921",
-      "name": "兆豐龍頭等權重"
+      "name": "兆豐龍頭等權重",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00922",
-      "name": "國泰台灣領袖50"
+      "name": "國泰台灣領袖50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00923",
-      "name": "群益台ESG低碳50"
+      "name": "群益台ESG低碳50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00924",
-      "name": "復華S&P500成長"
+      "name": "復華S&P500成長",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00926",
-      "name": "凱基全球菁英55"
+      "name": "凱基全球菁英55",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00927",
-      "name": "群益半導體收益"
+      "name": "群益半導體收益",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00929",
-      "name": "復華台灣科技優息"
+      "name": "復華台灣科技優息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00930",
-      "name": "永豐ESG低碳高息"
+      "name": "永豐ESG低碳高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00932",
-      "name": "兆豐永續高息等權"
+      "name": "兆豐永續高息等權",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00934",
-      "name": "中信成長高股息"
+      "name": "中信成長高股息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00935",
-      "name": "野村臺灣新科技50"
+      "name": "野村臺灣新科技50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00936",
-      "name": "台新永續高息中小"
+      "name": "台新永續高息中小",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00938",
-      "name": "凱基優選30"
+      "name": "凱基優選30",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00939",
-      "name": "統一台灣高息動能"
+      "name": "統一台灣高息動能",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00940",
-      "name": "元大台灣價值高息"
+      "name": "元大台灣價值高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00941",
-      "name": "中信上游半導體"
+      "name": "中信上游半導體",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00943",
-      "name": "兆豐電子高息等權"
+      "name": "兆豐電子高息等權",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00944",
-      "name": "野村趨勢動能高息"
+      "name": "野村趨勢動能高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00945B",
-      "name": "凱基美國非投等債"
+      "name": "凱基美國非投等債",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00946",
-      "name": "群益科技高息成長"
+      "name": "群益科技高息成長",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00947",
-      "name": "台新臺灣IC設計"
+      "name": "台新臺灣IC設計",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00949",
-      "name": "復華日本龍頭"
+      "name": "復華日本龍頭",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00951",
-      "name": "台新日本半導體"
+      "name": "台新日本半導體",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00952",
-      "name": "凱基台灣AI50"
+      "name": "凱基台灣AI50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00953B",
-      "name": "群益優選非投等債"
+      "name": "群益優選非投等債",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00954",
-      "name": "中信日本半導體"
+      "name": "中信日本半導體",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00956",
-      "name": "中信日經高股息"
+      "name": "中信日經高股息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00960",
-      "name": "野村全球航運龍頭"
+      "name": "野村全球航運龍頭",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00961",
-      "name": "FT臺灣永續高息"
+      "name": "FT臺灣永續高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00962",
-      "name": "台新AI優息動能"
+      "name": "台新AI優息動能",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00963",
-      "name": "中信全球高股息"
+      "name": "中信全球高股息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00964",
-      "name": "中信亞太高股息"
+      "name": "中信亞太高股息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00965",
-      "name": "元大航太防衛科技"
+      "name": "元大航太防衛科技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00971",
-      "name": "野村美國研發龍頭"
+      "name": "野村美國研發龍頭",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00972",
-      "name": "野村日本動能高息"
+      "name": "野村日本動能高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009800",
-      "name": "中信NASDAQ"
+      "name": "中信NASDAQ",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009801",
-      "name": "中信美國創新科技"
+      "name": "中信美國創新科技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009802",
-      "name": "富邦旗艦50"
+      "name": "富邦旗艦50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009803",
-      "name": "保德信市值動能50"
+      "name": "保德信市值動能50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009804",
-      "name": "聯邦台精彩50"
+      "name": "聯邦台精彩50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009805",
-      "name": "新光美國電力基建"
+      "name": "新光美國電力基建",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009808",
-      "name": "華南永昌優選50"
+      "name": "華南永昌優選50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009809",
-      "name": "富邦淨零ESG50"
+      "name": "富邦淨零ESG50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00980A",
-      "name": "主動野村臺灣優選"
+      "name": "主動野村臺灣優選",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009810",
-      "name": "保德信全球藍籌"
+      "name": "保德信全球藍籌",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009811",
-      "name": "統一美國50"
+      "name": "統一美國50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009812",
-      "name": "野村日本東證"
+      "name": "野村日本東證",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009813",
-      "name": "貝萊德標普卓越50"
+      "name": "貝萊德標普卓越50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009816",
-      "name": "凱基台灣TOP50"
+      "name": "凱基台灣TOP50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "009817",
-      "name": "國泰日本不動產"
+      "name": "國泰日本不動產",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00981A",
-      "name": "主動統一台股增長"
+      "name": "主動統一台股增長",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00981T",
-      "name": "平衡凱基雙核收息"
+      "name": "平衡凱基雙核收息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00982A",
-      "name": "主動群益台灣強棒"
+      "name": "主動群益台灣強棒",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00982D",
-      "name": "主動富邦動態入息"
+      "name": "主動富邦動態入息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00982T",
-      "name": "平衡兆豐台美動能"
+      "name": "平衡兆豐台美動能",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00983A",
-      "name": "主動中信ARK創新"
+      "name": "主動中信ARK創新",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00983D",
-      "name": "主動富邦複合收益"
+      "name": "主動富邦複合收益",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00984A",
-      "name": "主動安聯台灣高息"
+      "name": "主動安聯台灣高息",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00984D",
-      "name": "主動聯博全球非投"
+      "name": "主動聯博全球非投",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00985A",
-      "name": "主動野村台灣50"
+      "name": "主動野村台灣50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00985B",
-      "name": "群益ESG投等債0-5"
+      "name": "群益ESG投等債0-5",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00986A",
-      "name": "主動台新龍頭成長"
+      "name": "主動台新龍頭成長",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00987A",
-      "name": "主動台新優勢成長"
+      "name": "主動台新優勢成長",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00988A",
-      "name": "主動統一全球創新"
+      "name": "主動統一全球創新",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00989A",
-      "name": "主動摩根美國科技"
+      "name": "主動摩根美國科技",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00990A",
-      "name": "主動元大AI新經濟"
+      "name": "主動元大AI新經濟",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00991A",
-      "name": "主動復華未來50"
+      "name": "主動復華未來50",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00992A",
-      "name": "主動群益科技創新"
+      "name": "主動群益科技創新",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00993A",
-      "name": "主動安聯台灣"
+      "name": "主動安聯台灣",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00994A",
-      "name": "主動第一金台股優"
+      "name": "主動第一金台股優",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "00995A",
-      "name": "主動中信台灣卓越"
+      "name": "主動中信台灣卓越",
+      "type": "ETF",
+      "market": "上市",
+      "industry": ""
     },
     {
       "id": "1101",
-      "name": "台泥"
+      "name": "台泥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "水泥工業"
     },
     {
       "id": "1102",
-      "name": "亞泥"
+      "name": "亞泥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "水泥工業"
     },
     {
       "id": "1103",
-      "name": "嘉泥"
+      "name": "嘉泥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "水泥工業"
     },
     {
       "id": "1104",
-      "name": "環泥"
+      "name": "環泥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "水泥工業"
     },
     {
       "id": "1108",
-      "name": "幸福"
+      "name": "幸福",
+      "type": "股票",
+      "market": "上市",
+      "industry": "水泥工業"
     },
     {
       "id": "1109",
-      "name": "信大"
+      "name": "信大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "水泥工業"
     },
     {
       "id": "1110",
-      "name": "東泥"
+      "name": "東泥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "水泥工業"
     },
     {
       "id": "1201",
-      "name": "味全"
+      "name": "味全",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1203",
-      "name": "味王"
+      "name": "味王",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1210",
-      "name": "大成"
+      "name": "大成",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1213",
-      "name": "大飲"
+      "name": "大飲",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1215",
-      "name": "卜蜂"
+      "name": "卜蜂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1216",
-      "name": "統一"
+      "name": "統一",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1217",
-      "name": "愛之味"
+      "name": "愛之味",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1218",
-      "name": "泰山"
+      "name": "泰山",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1219",
-      "name": "福壽"
+      "name": "福壽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1220",
-      "name": "台榮"
+      "name": "台榮",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1225",
-      "name": "福懋油"
+      "name": "福懋油",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1227",
-      "name": "佳格"
+      "name": "佳格",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1229",
-      "name": "聯華"
+      "name": "聯華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1231",
-      "name": "聯華食"
+      "name": "聯華食",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1232",
-      "name": "大統益"
+      "name": "大統益",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1233",
-      "name": "天仁"
+      "name": "天仁",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1234",
-      "name": "黑松"
+      "name": "黑松",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1235",
-      "name": "興泰"
+      "name": "興泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1236",
-      "name": "宏亞"
+      "name": "宏亞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1256",
-      "name": "鮮活果汁-KY"
+      "name": "鮮活果汁-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1301",
-      "name": "台塑"
+      "name": "台塑",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1303",
-      "name": "南亞"
+      "name": "南亞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1304",
-      "name": "台聚"
+      "name": "台聚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1305",
-      "name": "華夏"
+      "name": "華夏",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1307",
-      "name": "三芳"
+      "name": "三芳",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1308",
-      "name": "亞聚"
+      "name": "亞聚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1309",
-      "name": "台達化"
+      "name": "台達化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1310",
-      "name": "台苯"
+      "name": "台苯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1312",
-      "name": "國喬"
+      "name": "國喬",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1313",
-      "name": "聯成"
+      "name": "聯成",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1314",
-      "name": "中石化"
+      "name": "中石化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1315",
-      "name": "達新"
+      "name": "達新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1316",
-      "name": "上曜"
+      "name": "上曜",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1319",
-      "name": "東陽"
+      "name": "東陽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1321",
-      "name": "大洋"
+      "name": "大洋",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1323",
-      "name": "永裕"
+      "name": "永裕",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1324",
-      "name": "地球"
+      "name": "地球",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1325",
-      "name": "恆大"
+      "name": "恆大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1326",
-      "name": "台化"
+      "name": "台化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1337",
-      "name": "再生-KY"
+      "name": "再生-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1338",
-      "name": "廣華-KY"
+      "name": "廣華-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1339",
-      "name": "昭輝"
+      "name": "昭輝",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1340",
-      "name": "勝悅-KY"
+      "name": "勝悅-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1341",
-      "name": "富林-KY"
+      "name": "富林-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "1342",
-      "name": "八貫"
+      "name": "八貫",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "1402",
-      "name": "遠東新"
+      "name": "遠東新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1409",
-      "name": "新纖"
+      "name": "新纖",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1410",
-      "name": "南染"
+      "name": "南染",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1413",
-      "name": "宏洲"
+      "name": "宏洲",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1414",
-      "name": "東和"
+      "name": "東和",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1416",
-      "name": "廣豐"
+      "name": "廣豐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "1417",
-      "name": "嘉裕"
+      "name": "嘉裕",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1418",
-      "name": "東華"
+      "name": "東華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1419",
-      "name": "新紡"
+      "name": "新紡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1423",
-      "name": "利華"
+      "name": "利華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1432",
-      "name": "大魯閣"
+      "name": "大魯閣",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "1434",
-      "name": "福懋"
+      "name": "福懋",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1435",
-      "name": "中福"
+      "name": "中福",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "1436",
-      "name": "華友聯"
+      "name": "華友聯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1437",
-      "name": "勤益控"
+      "name": "勤益控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "1438",
-      "name": "三地開發"
+      "name": "三地開發",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1439",
-      "name": "雋揚"
+      "name": "雋揚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1440",
-      "name": "南紡"
+      "name": "南紡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1441",
-      "name": "大東"
+      "name": "大東",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1442",
-      "name": "名軒"
+      "name": "名軒",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1443",
-      "name": "立益物流"
+      "name": "立益物流",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "1444",
-      "name": "力麗"
+      "name": "力麗",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1445",
-      "name": "大宇"
+      "name": "大宇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1446",
-      "name": "宏和"
+      "name": "宏和",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1447",
-      "name": "力鵬"
+      "name": "力鵬",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1449",
-      "name": "佳和"
+      "name": "佳和",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1451",
-      "name": "年興"
+      "name": "年興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1452",
-      "name": "宏益"
+      "name": "宏益",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1453",
-      "name": "大將"
+      "name": "大將",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1454",
-      "name": "台富"
+      "name": "台富",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1455",
-      "name": "集盛"
+      "name": "集盛",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1456",
-      "name": "怡華"
+      "name": "怡華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1457",
-      "name": "宜進"
+      "name": "宜進",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1459",
-      "name": "聯發"
+      "name": "聯發",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1460",
-      "name": "宏遠"
+      "name": "宏遠",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1463",
-      "name": "強盛新"
+      "name": "強盛新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1464",
-      "name": "得力"
+      "name": "得力",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1465",
-      "name": "偉全"
+      "name": "偉全",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1466",
-      "name": "聚隆"
+      "name": "聚隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1467",
-      "name": "南緯"
+      "name": "南緯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1468",
-      "name": "昶和"
+      "name": "昶和",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1470",
-      "name": "大統新創"
+      "name": "大統新創",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1471",
-      "name": "首利"
+      "name": "首利",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "1472",
-      "name": "三洋實業"
+      "name": "三洋實業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1473",
-      "name": "台南"
+      "name": "台南",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1474",
-      "name": "弘裕"
+      "name": "弘裕",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1475",
-      "name": "業旺"
+      "name": "業旺",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1476",
-      "name": "儒鴻"
+      "name": "儒鴻",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1477",
-      "name": "聚陽"
+      "name": "聚陽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "1503",
-      "name": "士電"
+      "name": "士電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1504",
-      "name": "東元"
+      "name": "東元",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1506",
-      "name": "正道"
+      "name": "正道",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1512",
-      "name": "瑞利"
+      "name": "瑞利",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1513",
-      "name": "中興電"
+      "name": "中興電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1514",
-      "name": "亞力"
+      "name": "亞力",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1515",
-      "name": "力山"
+      "name": "力山",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1516",
-      "name": "川飛"
+      "name": "川飛",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "1517",
-      "name": "利奇"
+      "name": "利奇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1519",
-      "name": "華城"
+      "name": "華城",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1521",
-      "name": "大億"
+      "name": "大億",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1522",
-      "name": "堤維西"
+      "name": "堤維西",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1524",
-      "name": "耿鼎"
+      "name": "耿鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1525",
-      "name": "江申"
+      "name": "江申",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1526",
-      "name": "日馳"
+      "name": "日馳",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1527",
-      "name": "鑽全"
+      "name": "鑽全",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1528",
-      "name": "恩德"
+      "name": "恩德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1529",
-      "name": "樂事綠能"
+      "name": "樂事綠能",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1530",
-      "name": "亞崴"
+      "name": "亞崴",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1531",
-      "name": "高林股"
+      "name": "高林股",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1532",
-      "name": "勤美"
+      "name": "勤美",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1533",
-      "name": "車王電"
+      "name": "車王電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1535",
-      "name": "中宇"
+      "name": "中宇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1536",
-      "name": "和大"
+      "name": "和大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1537",
-      "name": "廣隆"
+      "name": "廣隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1538",
-      "name": "正峰"
+      "name": "正峰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1539",
-      "name": "巨庭"
+      "name": "巨庭",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1540",
-      "name": "喬福"
+      "name": "喬福",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1541",
-      "name": "錩泰"
+      "name": "錩泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1558",
-      "name": "伸興"
+      "name": "伸興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1560",
-      "name": "中砂"
+      "name": "中砂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1563",
-      "name": "巧新"
+      "name": "巧新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1568",
-      "name": "倉佑"
+      "name": "倉佑",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1582",
-      "name": "信錦"
+      "name": "信錦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "1583",
-      "name": "程泰"
+      "name": "程泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1587",
-      "name": "吉茂"
+      "name": "吉茂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "1589",
-      "name": "永冠-KY"
+      "name": "永冠-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1590",
-      "name": "亞德客-KY"
+      "name": "亞德客-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1597",
-      "name": "直得"
+      "name": "直得",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "1598",
-      "name": "岱宇"
+      "name": "岱宇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "1603",
-      "name": "華電"
+      "name": "華電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1604",
-      "name": "聲寶"
+      "name": "聲寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1605",
-      "name": "華新"
+      "name": "華新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1608",
-      "name": "華榮"
+      "name": "華榮",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1609",
-      "name": "大亞"
+      "name": "大亞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1611",
-      "name": "中電"
+      "name": "中電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1612",
-      "name": "宏泰"
+      "name": "宏泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1614",
-      "name": "三洋電"
+      "name": "三洋電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1615",
-      "name": "大山"
+      "name": "大山",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1616",
-      "name": "億泰"
+      "name": "億泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1617",
-      "name": "榮星"
+      "name": "榮星",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1618",
-      "name": "合機"
+      "name": "合機",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1623",
-      "name": "大東電"
+      "name": "大東電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1626",
-      "name": "艾美特-KY"
+      "name": "艾美特-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "1702",
-      "name": "南僑"
+      "name": "南僑",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1707",
-      "name": "葡萄王"
+      "name": "葡萄王",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1708",
-      "name": "東鹼"
+      "name": "東鹼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1709",
-      "name": "和益"
+      "name": "和益",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1710",
-      "name": "東聯"
+      "name": "東聯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1711",
-      "name": "永光"
+      "name": "永光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1712",
-      "name": "興農"
+      "name": "興農",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1713",
-      "name": "國化"
+      "name": "國化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1714",
-      "name": "和桐"
+      "name": "和桐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1717",
-      "name": "長興"
+      "name": "長興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1718",
-      "name": "中纖"
+      "name": "中纖",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1720",
-      "name": "生達"
+      "name": "生達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1721",
-      "name": "三晃"
+      "name": "三晃",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1722",
-      "name": "台肥"
+      "name": "台肥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1723",
-      "name": "中碳"
+      "name": "中碳",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1725",
-      "name": "元禎"
+      "name": "元禎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1726",
-      "name": "永記"
+      "name": "永記",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1727",
-      "name": "中華化"
+      "name": "中華化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1730",
-      "name": "花仙子"
+      "name": "花仙子",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1731",
-      "name": "美吾華"
+      "name": "美吾華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1732",
-      "name": "毛寶"
+      "name": "毛寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1733",
-      "name": "五鼎"
+      "name": "五鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1734",
-      "name": "杏輝"
+      "name": "杏輝",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1735",
-      "name": "日勝化"
+      "name": "日勝化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1736",
-      "name": "喬山"
+      "name": "喬山",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "1737",
-      "name": "臺鹽"
+      "name": "臺鹽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "1752",
-      "name": "南光"
+      "name": "南光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1760",
-      "name": "寶齡富錦"
+      "name": "寶齡富錦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1762",
-      "name": "中化生"
+      "name": "中化生",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1773",
-      "name": "勝一"
+      "name": "勝一",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1776",
-      "name": "展宇"
+      "name": "展宇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "1783",
-      "name": "和康生"
+      "name": "和康生",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1786",
-      "name": "科妍"
+      "name": "科妍",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1789",
-      "name": "神隆"
+      "name": "神隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1795",
-      "name": "美時"
+      "name": "美時",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "1802",
-      "name": "台玻"
+      "name": "台玻",
+      "type": "股票",
+      "market": "上市",
+      "industry": "玻璃陶瓷"
     },
     {
       "id": "1805",
-      "name": "寶徠"
+      "name": "寶徠",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1806",
-      "name": "冠軍"
+      "name": "冠軍",
+      "type": "股票",
+      "market": "上市",
+      "industry": "玻璃陶瓷"
     },
     {
       "id": "1808",
-      "name": "潤隆"
+      "name": "潤隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "1809",
-      "name": "中釉"
+      "name": "中釉",
+      "type": "股票",
+      "market": "上市",
+      "industry": "玻璃陶瓷"
     },
     {
       "id": "1810",
-      "name": "和成"
+      "name": "和成",
+      "type": "股票",
+      "market": "上市",
+      "industry": "玻璃陶瓷"
     },
     {
       "id": "1817",
-      "name": "凱撒衛"
+      "name": "凱撒衛",
+      "type": "股票",
+      "market": "上市",
+      "industry": "玻璃陶瓷"
     },
     {
       "id": "1903",
-      "name": "士紙"
+      "name": "士紙",
+      "type": "股票",
+      "market": "上市",
+      "industry": "造紙工業"
     },
     {
       "id": "1904",
-      "name": "正隆"
+      "name": "正隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "造紙工業"
     },
     {
       "id": "1905",
-      "name": "華紙"
+      "name": "華紙",
+      "type": "股票",
+      "market": "上市",
+      "industry": "造紙工業"
     },
     {
       "id": "1906",
-      "name": "寶隆"
+      "name": "寶隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "造紙工業"
     },
     {
       "id": "1907",
-      "name": "永豐餘"
+      "name": "永豐餘",
+      "type": "股票",
+      "market": "上市",
+      "industry": "造紙工業"
     },
     {
       "id": "1909",
-      "name": "榮成"
+      "name": "榮成",
+      "type": "股票",
+      "market": "上市",
+      "industry": "造紙工業"
     },
     {
       "id": "2002",
-      "name": "中鋼"
+      "name": "中鋼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2006",
-      "name": "東和鋼鐵"
+      "name": "東和鋼鐵",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2007",
-      "name": "燁興"
+      "name": "燁興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2008",
-      "name": "高興昌"
+      "name": "高興昌",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2009",
-      "name": "第一銅"
+      "name": "第一銅",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2010",
-      "name": "春源"
+      "name": "春源",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2012",
-      "name": "春雨"
+      "name": "春雨",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2013",
-      "name": "中鋼構"
+      "name": "中鋼構",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2014",
-      "name": "中鴻"
+      "name": "中鴻",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2015",
-      "name": "豐興"
+      "name": "豐興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2017",
-      "name": "官田鋼"
+      "name": "官田鋼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2020",
-      "name": "美亞"
+      "name": "美亞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2022",
-      "name": "聚亨"
+      "name": "聚亨",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2023",
-      "name": "燁輝"
+      "name": "燁輝",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2024",
-      "name": "志聯"
+      "name": "志聯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2025",
-      "name": "千興"
+      "name": "千興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2027",
-      "name": "大成鋼"
+      "name": "大成鋼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2028",
-      "name": "威致"
+      "name": "威致",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2029",
-      "name": "盛餘"
+      "name": "盛餘",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2030",
-      "name": "彰源"
+      "name": "彰源",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2031",
-      "name": "新光鋼"
+      "name": "新光鋼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2032",
-      "name": "新鋼"
+      "name": "新鋼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2033",
-      "name": "佳大"
+      "name": "佳大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2034",
-      "name": "允強"
+      "name": "允強",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2038",
-      "name": "海光"
+      "name": "海光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2049",
-      "name": "上銀"
+      "name": "上銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "2059",
-      "name": "川湖"
+      "name": "川湖",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2062",
-      "name": "橋椿"
+      "name": "橋椿",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "2069",
-      "name": "運錩"
+      "name": "運錩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2101",
-      "name": "南港"
+      "name": "南港",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2102",
-      "name": "泰豐"
+      "name": "泰豐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2103",
-      "name": "台橡"
+      "name": "台橡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2104",
-      "name": "國際中橡"
+      "name": "國際中橡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2105",
-      "name": "正新"
+      "name": "正新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2106",
-      "name": "建大"
+      "name": "建大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2107",
-      "name": "厚生"
+      "name": "厚生",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2108",
-      "name": "南帝"
+      "name": "南帝",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2109",
-      "name": "華豐"
+      "name": "華豐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2114",
-      "name": "鑫永銓"
+      "name": "鑫永銓",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "2115",
-      "name": "六暉-KY"
+      "name": "六暉-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2201",
-      "name": "裕隆"
+      "name": "裕隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2204",
-      "name": "中華"
+      "name": "中華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2206",
-      "name": "三陽工業"
+      "name": "三陽工業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2207",
-      "name": "和泰車"
+      "name": "和泰車",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2208",
-      "name": "台船"
+      "name": "台船",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2211",
-      "name": "長榮鋼"
+      "name": "長榮鋼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "2227",
-      "name": "裕日車"
+      "name": "裕日車",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2228",
-      "name": "劍麟"
+      "name": "劍麟",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2231",
-      "name": "為升"
+      "name": "為升",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2233",
-      "name": "宇隆"
+      "name": "宇隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2236",
-      "name": "百達-KY"
+      "name": "百達-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2239",
-      "name": "英利-KY"
+      "name": "英利-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2241",
-      "name": "艾姆勒"
+      "name": "艾姆勒",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2243",
-      "name": "宏旭-KY"
+      "name": "宏旭-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2247",
-      "name": "汎德永業"
+      "name": "汎德永業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2248",
-      "name": "華勝-KY"
+      "name": "華勝-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2250",
-      "name": "IKKA-KY"
+      "name": "IKKA-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2301",
-      "name": "光寶科"
+      "name": "光寶科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2302",
-      "name": "麗正"
+      "name": "麗正",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2303",
-      "name": "聯電"
+      "name": "聯電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2305",
-      "name": "全友"
+      "name": "全友",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2308",
-      "name": "台達電"
+      "name": "台達電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2312",
-      "name": "金寶"
+      "name": "金寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2313",
-      "name": "華通"
+      "name": "華通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2314",
-      "name": "台揚"
+      "name": "台揚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2316",
-      "name": "楠梓電"
+      "name": "楠梓電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2317",
-      "name": "鴻海"
+      "name": "鴻海",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2321",
-      "name": "東訊"
+      "name": "東訊",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2323",
-      "name": "中環"
+      "name": "中環",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2324",
-      "name": "仁寶"
+      "name": "仁寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2327",
-      "name": "國巨*"
+      "name": "國巨*",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2328",
-      "name": "廣宇"
+      "name": "廣宇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2329",
-      "name": "華泰"
+      "name": "華泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2330",
-      "name": "台積電"
+      "name": "台積電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2331",
-      "name": "精英"
+      "name": "精英",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2332",
-      "name": "友訊"
+      "name": "友訊",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2337",
-      "name": "旺宏"
+      "name": "旺宏",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2338",
-      "name": "光罩"
+      "name": "光罩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2340",
-      "name": "台亞"
+      "name": "台亞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2342",
-      "name": "茂矽"
+      "name": "茂矽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2344",
-      "name": "華邦電"
+      "name": "華邦電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2345",
-      "name": "智邦"
+      "name": "智邦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2347",
-      "name": "聯強"
+      "name": "聯強",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "2348",
-      "name": "海悅"
+      "name": "海悅",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "2349",
-      "name": "錸德"
+      "name": "錸德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2351",
-      "name": "順德"
+      "name": "順德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2352",
-      "name": "佳世達"
+      "name": "佳世達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2353",
-      "name": "宏��"
+      "name": "宏��",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2354",
-      "name": "鴻準"
+      "name": "鴻準",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2355",
-      "name": "敬鵬"
+      "name": "敬鵬",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2356",
-      "name": "英業達"
+      "name": "英業達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2357",
-      "name": "華碩"
+      "name": "華碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2359",
-      "name": "所羅門"
+      "name": "所羅門",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2360",
-      "name": "致茂"
+      "name": "致茂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2362",
-      "name": "藍天"
+      "name": "藍天",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2363",
-      "name": "矽統"
+      "name": "矽統",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2364",
-      "name": "倫飛"
+      "name": "倫飛",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2365",
-      "name": "昆盈"
+      "name": "昆盈",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2367",
-      "name": "燿華"
+      "name": "燿華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2368",
-      "name": "金像電"
+      "name": "金像電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2369",
-      "name": "菱生"
+      "name": "菱生",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2371",
-      "name": "大同"
+      "name": "大同",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "2373",
-      "name": "震旦行"
+      "name": "震旦行",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2374",
-      "name": "佳能"
+      "name": "佳能",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2375",
-      "name": "凱美"
+      "name": "凱美",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2376",
-      "name": "技嘉"
+      "name": "技嘉",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2377",
-      "name": "微星"
+      "name": "微星",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2379",
-      "name": "瑞昱"
+      "name": "瑞昱",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2380",
-      "name": "虹光"
+      "name": "虹光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2382",
-      "name": "廣達"
+      "name": "廣達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2383",
-      "name": "台光電"
+      "name": "台光電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2385",
-      "name": "群光"
+      "name": "群光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2387",
-      "name": "精元"
+      "name": "精元",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2388",
-      "name": "威盛"
+      "name": "威盛",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2390",
-      "name": "云辰"
+      "name": "云辰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2392",
-      "name": "正崴"
+      "name": "正崴",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2393",
-      "name": "億光"
+      "name": "億光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2395",
-      "name": "研華"
+      "name": "研華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2397",
-      "name": "友通"
+      "name": "友通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2399",
-      "name": "映泰"
+      "name": "映泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2401",
-      "name": "凌陽"
+      "name": "凌陽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2402",
-      "name": "毅嘉"
+      "name": "毅嘉",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2404",
-      "name": "漢唐"
+      "name": "漢唐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2405",
-      "name": "輔信"
+      "name": "輔信",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2406",
-      "name": "國碩"
+      "name": "國碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2408",
-      "name": "南亞科"
+      "name": "南亞科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2409",
-      "name": "友達"
+      "name": "友達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2412",
-      "name": "中華電"
+      "name": "中華電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2413",
-      "name": "環科"
+      "name": "環科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2414",
-      "name": "精技"
+      "name": "精技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "2415",
-      "name": "錩新"
+      "name": "錩新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2417",
-      "name": "圓剛"
+      "name": "圓剛",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2419",
-      "name": "仲琦"
+      "name": "仲琦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2420",
-      "name": "新巨"
+      "name": "新巨",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2421",
-      "name": "建準"
+      "name": "建準",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2423",
-      "name": "固緯"
+      "name": "固緯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2424",
-      "name": "隴華"
+      "name": "隴華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2425",
-      "name": "承啟"
+      "name": "承啟",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2426",
-      "name": "鼎元"
+      "name": "鼎元",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2427",
-      "name": "三商電"
+      "name": "三商電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "2428",
-      "name": "興勤"
+      "name": "興勤",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2429",
-      "name": "銘旺科"
+      "name": "銘旺科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2430",
-      "name": "燦坤"
+      "name": "燦坤",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "2431",
-      "name": "聯昌"
+      "name": "聯昌",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2433",
-      "name": "互盛電"
+      "name": "互盛電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2434",
-      "name": "統懋"
+      "name": "統懋",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2436",
-      "name": "偉詮電"
+      "name": "偉詮電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2438",
-      "name": "翔耀"
+      "name": "翔耀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2439",
-      "name": "美律"
+      "name": "美律",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2440",
-      "name": "太空梭"
+      "name": "太空梭",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2441",
-      "name": "超豐"
+      "name": "超豐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2442",
-      "name": "新美齊"
+      "name": "新美齊",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2444",
-      "name": "兆勁"
+      "name": "兆勁",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2449",
-      "name": "京元電子"
+      "name": "京元電子",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2450",
-      "name": "神腦"
+      "name": "神腦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2451",
-      "name": "創見"
+      "name": "創見",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2453",
-      "name": "凌群"
+      "name": "凌群",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "2454",
-      "name": "聯發科"
+      "name": "聯發科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2455",
-      "name": "全新"
+      "name": "全新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2457",
-      "name": "飛宏"
+      "name": "飛宏",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2458",
-      "name": "義隆"
+      "name": "義隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2459",
-      "name": "敦吉"
+      "name": "敦吉",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2460",
-      "name": "建通"
+      "name": "建通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2461",
-      "name": "光群雷"
+      "name": "光群雷",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2462",
-      "name": "良得電"
+      "name": "良得電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2464",
-      "name": "盟立"
+      "name": "盟立",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2465",
-      "name": "麗臺"
+      "name": "麗臺",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2466",
-      "name": "冠西電"
+      "name": "冠西電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2467",
-      "name": "志聖"
+      "name": "志聖",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2468",
-      "name": "華經"
+      "name": "華經",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "2471",
-      "name": "資通"
+      "name": "資通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "2472",
-      "name": "立隆電"
+      "name": "立隆電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2474",
-      "name": "可成"
+      "name": "可成",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2476",
-      "name": "鉅祥"
+      "name": "鉅祥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2477",
-      "name": "美隆電"
+      "name": "美隆電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2478",
-      "name": "大毅"
+      "name": "大毅",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2480",
-      "name": "敦陽科"
+      "name": "敦陽科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "2481",
-      "name": "強茂"
+      "name": "強茂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "2482",
-      "name": "連宇"
+      "name": "連宇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2483",
-      "name": "百容"
+      "name": "百容",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2484",
-      "name": "希華"
+      "name": "希華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2485",
-      "name": "兆赫"
+      "name": "兆赫",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2486",
-      "name": "一詮"
+      "name": "一詮",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2488",
-      "name": "漢平"
+      "name": "漢平",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "2489",
-      "name": "瑞軒"
+      "name": "瑞軒",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2491",
-      "name": "吉祥全"
+      "name": "吉祥全",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "2492",
-      "name": "華新科"
+      "name": "華新科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2493",
-      "name": "揚博"
+      "name": "揚博",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "2495",
-      "name": "普安"
+      "name": "普安",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "2496",
-      "name": "卓越"
+      "name": "卓越",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "2497",
-      "name": "怡利電"
+      "name": "怡利電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "2498",
-      "name": "宏達電"
+      "name": "宏達電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "2501",
-      "name": "國建"
+      "name": "國建",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2504",
-      "name": "國產"
+      "name": "國產",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2505",
-      "name": "國揚"
+      "name": "國揚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2506",
-      "name": "太設"
+      "name": "太設",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2509",
-      "name": "全坤建"
+      "name": "全坤建",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2511",
-      "name": "太子"
+      "name": "太子",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2514",
-      "name": "龍邦"
+      "name": "龍邦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "2515",
-      "name": "中工"
+      "name": "中工",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2516",
-      "name": "新建"
+      "name": "新建",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2520",
-      "name": "冠德"
+      "name": "冠德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2524",
-      "name": "京城"
+      "name": "京城",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2527",
-      "name": "宏璟"
+      "name": "宏璟",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2528",
-      "name": "皇普"
+      "name": "皇普",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2530",
-      "name": "華建"
+      "name": "華建",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2534",
-      "name": "宏盛"
+      "name": "宏盛",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2535",
-      "name": "達欣工"
+      "name": "達欣工",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2536",
-      "name": "宏普"
+      "name": "宏普",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2537",
-      "name": "聯上發"
+      "name": "聯上發",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2538",
-      "name": "基泰"
+      "name": "基泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2539",
-      "name": "櫻花建"
+      "name": "櫻花建",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2540",
-      "name": "愛山林"
+      "name": "愛山林",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2542",
-      "name": "興富發"
+      "name": "興富發",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2543",
-      "name": "皇昌"
+      "name": "皇昌",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2545",
-      "name": "皇翔"
+      "name": "皇翔",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2546",
-      "name": "根基"
+      "name": "根基",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2547",
-      "name": "日勝生"
+      "name": "日勝生",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2548",
-      "name": "華固"
+      "name": "華固",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2597",
-      "name": "潤弘"
+      "name": "潤弘",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2601",
-      "name": "益航"
+      "name": "益航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2603",
-      "name": "長榮"
+      "name": "長榮",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2605",
-      "name": "新興"
+      "name": "新興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2606",
-      "name": "裕民"
+      "name": "裕民",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2607",
-      "name": "榮運"
+      "name": "榮運",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2608",
-      "name": "嘉里大榮"
+      "name": "嘉里大榮",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2609",
-      "name": "陽明"
+      "name": "陽明",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2610",
-      "name": "華航"
+      "name": "華航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2611",
-      "name": "志信"
+      "name": "志信",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2612",
-      "name": "中航"
+      "name": "中航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2613",
-      "name": "中櫃"
+      "name": "中櫃",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2614",
-      "name": "東森"
+      "name": "東森",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "2615",
-      "name": "萬海"
+      "name": "萬海",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2616",
-      "name": "山隆"
+      "name": "山隆",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "2617",
-      "name": "台航"
+      "name": "台航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2618",
-      "name": "長榮航"
+      "name": "長榮航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2630",
-      "name": "亞航"
+      "name": "亞航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2633",
-      "name": "台灣高鐵"
+      "name": "台灣高鐵",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2634",
-      "name": "漢翔"
+      "name": "漢翔",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2636",
-      "name": "台驊控股"
+      "name": "台驊控股",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2637",
-      "name": "慧洋-KY"
+      "name": "慧洋-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2642",
-      "name": "宅配通"
+      "name": "宅配通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2645",
-      "name": "長榮航太"
+      "name": "長榮航太",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2646",
-      "name": "星宇航空"
+      "name": "星宇航空",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "2701",
-      "name": "萬企"
+      "name": "萬企",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2702",
-      "name": "華園"
+      "name": "華園",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2704",
-      "name": "國賓"
+      "name": "國賓",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2705",
-      "name": "六福"
+      "name": "六福",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2706",
-      "name": "第一店"
+      "name": "第一店",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2707",
-      "name": "晶華"
+      "name": "晶華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2712",
-      "name": "遠雄來"
+      "name": "遠雄來",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2722",
-      "name": "夏都"
+      "name": "夏都",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2723",
-      "name": "美食-KY"
+      "name": "美食-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2727",
-      "name": "王品"
+      "name": "王品",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2731",
-      "name": "雄獅"
+      "name": "雄獅",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2739",
-      "name": "寒舍"
+      "name": "寒舍",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2748",
-      "name": "雲品"
+      "name": "雲品",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2753",
-      "name": "八方雲集"
+      "name": "八方雲集",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "2762",
-      "name": "世界健身-KY"
+      "name": "世界健身-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "2801",
-      "name": "彰銀"
+      "name": "彰銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2812",
-      "name": "台中銀"
+      "name": "台中銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2816",
-      "name": "旺旺保"
+      "name": "旺旺保",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2820",
-      "name": "華票"
+      "name": "華票",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2832",
-      "name": "台產"
+      "name": "台產",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2834",
-      "name": "臺企銀"
+      "name": "臺企銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2836",
-      "name": "高雄銀"
+      "name": "高雄銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2838",
-      "name": "聯邦銀"
+      "name": "聯邦銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2845",
-      "name": "遠東銀"
+      "name": "遠東銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2849",
-      "name": "安泰銀"
+      "name": "安泰銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2850",
-      "name": "新產"
+      "name": "新產",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2851",
-      "name": "中再保"
+      "name": "中再保",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2852",
-      "name": "第一保"
+      "name": "第一保",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2855",
-      "name": "統一證"
+      "name": "統一證",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2867",
-      "name": "三商壽"
+      "name": "三商壽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2880",
-      "name": "華南金"
+      "name": "華南金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2881",
-      "name": "富邦金"
+      "name": "富邦金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2882",
-      "name": "國泰金"
+      "name": "國泰金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2883",
-      "name": "凱基金"
+      "name": "凱基金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2884",
-      "name": "玉山金"
+      "name": "玉山金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2885",
-      "name": "元大金"
+      "name": "元大金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2886",
-      "name": "兆豐金"
+      "name": "兆豐金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2887",
-      "name": "台新新光金"
+      "name": "台新新光金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2889",
-      "name": "國票金"
+      "name": "國票金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2890",
-      "name": "永豐金"
+      "name": "永豐金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2891",
-      "name": "中信金"
+      "name": "中信金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2892",
-      "name": "第一金"
+      "name": "第一金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2897",
-      "name": "王道銀行"
+      "name": "王道銀行",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "2901",
-      "name": "欣欣"
+      "name": "欣欣",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2903",
-      "name": "遠百"
+      "name": "遠百",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2904",
-      "name": "匯僑"
+      "name": "匯僑",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "2905",
-      "name": "三商"
+      "name": "三商",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2906",
-      "name": "高林"
+      "name": "高林",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2908",
-      "name": "特力"
+      "name": "特力",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2910",
-      "name": "統領"
+      "name": "統領",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2911",
-      "name": "麗嬰房"
+      "name": "麗嬰房",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2912",
-      "name": "統一超"
+      "name": "統一超",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2913",
-      "name": "農林"
+      "name": "農林",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2915",
-      "name": "潤泰全"
+      "name": "潤泰全",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2923",
-      "name": "鼎固-KY"
+      "name": "鼎固-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "2929",
-      "name": "淘帝-KY"
+      "name": "淘帝-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2939",
-      "name": "永邑-KY"
+      "name": "永邑-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "2945",
-      "name": "三商家購"
+      "name": "三商家購",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "3002",
-      "name": "歐格"
+      "name": "歐格",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3003",
-      "name": "健和興"
+      "name": "健和興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3004",
-      "name": "豐達科"
+      "name": "豐達科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "3005",
-      "name": "神基"
+      "name": "神基",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3006",
-      "name": "晶豪科"
+      "name": "晶豪科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3008",
-      "name": "大立光"
+      "name": "大立光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3010",
-      "name": "華立"
+      "name": "華立",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3011",
-      "name": "今皓"
+      "name": "今皓",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3013",
-      "name": "晟銘電"
+      "name": "晟銘電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3014",
-      "name": "聯陽"
+      "name": "聯陽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3015",
-      "name": "全漢"
+      "name": "全漢",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3016",
-      "name": "嘉晶"
+      "name": "嘉晶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3017",
-      "name": "奇鋐"
+      "name": "奇鋐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3018",
-      "name": "隆銘綠能"
+      "name": "隆銘綠能",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "3019",
-      "name": "亞光"
+      "name": "亞光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3021",
-      "name": "鴻名"
+      "name": "鴻名",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3022",
-      "name": "威強電"
+      "name": "威強電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3023",
-      "name": "信邦"
+      "name": "信邦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3024",
-      "name": "憶聲"
+      "name": "憶聲",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3025",
-      "name": "星通"
+      "name": "星通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3026",
-      "name": "禾伸堂"
+      "name": "禾伸堂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3027",
-      "name": "盛達"
+      "name": "盛達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3028",
-      "name": "增你強"
+      "name": "增你強",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3029",
-      "name": "零壹"
+      "name": "零壹",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "3030",
-      "name": "德律"
+      "name": "德律",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "3031",
-      "name": "佰鴻"
+      "name": "佰鴻",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3032",
-      "name": "偉訓"
+      "name": "偉訓",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3033",
-      "name": "威健"
+      "name": "威健",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3034",
-      "name": "聯詠"
+      "name": "聯詠",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3035",
-      "name": "智原"
+      "name": "智原",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3036",
-      "name": "文曄"
+      "name": "文曄",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3037",
-      "name": "欣興"
+      "name": "欣興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3038",
-      "name": "全台"
+      "name": "全台",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3040",
-      "name": "遠見"
+      "name": "遠見",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "3041",
-      "name": "揚智"
+      "name": "揚智",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3042",
-      "name": "晶技"
+      "name": "晶技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3043",
-      "name": "科風"
+      "name": "科風",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "3044",
-      "name": "健鼎"
+      "name": "健鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3045",
-      "name": "台灣大"
+      "name": "台灣大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3046",
-      "name": "建��"
+      "name": "建��",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3047",
-      "name": "訊舟"
+      "name": "訊舟",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3048",
-      "name": "益登"
+      "name": "益登",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3049",
-      "name": "精金"
+      "name": "精金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3050",
-      "name": "鈺德"
+      "name": "鈺德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3051",
-      "name": "力特"
+      "name": "力特",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3052",
-      "name": "夆典"
+      "name": "夆典",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "3054",
-      "name": "立萬利"
+      "name": "立萬利",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "3055",
-      "name": "蔚華科"
+      "name": "蔚華科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3056",
-      "name": "富華新"
+      "name": "富華新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "3057",
-      "name": "喬鼎"
+      "name": "喬鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3058",
-      "name": "立德"
+      "name": "立德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3059",
-      "name": "華晶科"
+      "name": "華晶科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3060",
-      "name": "銘異"
+      "name": "銘異",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3062",
-      "name": "建漢"
+      "name": "建漢",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3090",
-      "name": "日電貿"
+      "name": "日電貿",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3092",
-      "name": "鴻碩"
+      "name": "鴻碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3094",
-      "name": "聯傑"
+      "name": "聯傑",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3130",
-      "name": "一零四"
+      "name": "一零四",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "3135",
-      "name": "凌航"
+      "name": "凌航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3138",
-      "name": "耀登"
+      "name": "耀登",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3149",
-      "name": "正達"
+      "name": "正達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3164",
-      "name": "景岳"
+      "name": "景岳",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "3167",
-      "name": "大量"
+      "name": "大量",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "3168",
-      "name": "眾福科"
+      "name": "眾福科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3189",
-      "name": "景碩"
+      "name": "景碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3209",
-      "name": "全科"
+      "name": "全科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3229",
-      "name": "晟鈦"
+      "name": "晟鈦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3231",
-      "name": "緯創"
+      "name": "緯創",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3257",
-      "name": "虹冠電"
+      "name": "虹冠電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3266",
-      "name": "昇陽"
+      "name": "昇陽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "3296",
-      "name": "勝德"
+      "name": "勝德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3305",
-      "name": "昇貿"
+      "name": "昇貿",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "3308",
-      "name": "聯德"
+      "name": "聯德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3311",
-      "name": "閎暉"
+      "name": "閎暉",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3312",
-      "name": "弘憶股"
+      "name": "弘憶股",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3321",
-      "name": "同泰"
+      "name": "同泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3338",
-      "name": "泰碩"
+      "name": "泰碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3346",
-      "name": "麗清"
+      "name": "麗清",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "3356",
-      "name": "奇偶"
+      "name": "奇偶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3376",
-      "name": "新日興"
+      "name": "新日興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3380",
-      "name": "明泰"
+      "name": "明泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3406",
-      "name": "玉晶光"
+      "name": "玉晶光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3413",
-      "name": "京鼎"
+      "name": "京鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3416",
-      "name": "融程電"
+      "name": "融程電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3419",
-      "name": "譁裕"
+      "name": "譁裕",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3432",
-      "name": "台端"
+      "name": "台端",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3437",
-      "name": "榮創"
+      "name": "榮創",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3443",
-      "name": "創意"
+      "name": "創意",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3447",
-      "name": "展達"
+      "name": "展達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3450",
-      "name": "聯鈞"
+      "name": "聯鈞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3454",
-      "name": "晶睿"
+      "name": "晶睿",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3481",
-      "name": "群創"
+      "name": "群創",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3494",
-      "name": "誠研"
+      "name": "誠研",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3501",
-      "name": "維熹"
+      "name": "維熹",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3504",
-      "name": "揚明光"
+      "name": "揚明光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3515",
-      "name": "華擎"
+      "name": "華擎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3518",
-      "name": "柏騰"
+      "name": "柏騰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "3528",
-      "name": "安馳"
+      "name": "安馳",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3530",
-      "name": "晶相光"
+      "name": "晶相光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3532",
-      "name": "台勝科"
+      "name": "台勝科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3533",
-      "name": "嘉澤"
+      "name": "嘉澤",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3535",
-      "name": "晶彩科"
+      "name": "晶彩科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3543",
-      "name": "州巧"
+      "name": "州巧",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3545",
-      "name": "敦泰"
+      "name": "敦泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3550",
-      "name": "聯穎"
+      "name": "聯穎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3557",
-      "name": "嘉威"
+      "name": "嘉威",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "3563",
-      "name": "牧德"
+      "name": "牧德",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3576",
-      "name": "聯合再生"
+      "name": "聯合再生",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3583",
-      "name": "辛耘"
+      "name": "辛耘",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3588",
-      "name": "通嘉"
+      "name": "通嘉",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3591",
-      "name": "艾笛森"
+      "name": "艾笛森",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3592",
-      "name": "瑞鼎"
+      "name": "瑞鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3593",
-      "name": "力銘"
+      "name": "力銘",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3596",
-      "name": "智易"
+      "name": "智易",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3605",
-      "name": "宏致"
+      "name": "宏致",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3607",
-      "name": "谷崧"
+      "name": "谷崧",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3617",
-      "name": "碩天"
+      "name": "碩天",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "3622",
-      "name": "洋華"
+      "name": "洋華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3645",
-      "name": "達邁"
+      "name": "達邁",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3652",
-      "name": "精聯"
+      "name": "精聯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3653",
-      "name": "健策"
+      "name": "健策",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3661",
-      "name": "世芯-KY"
+      "name": "世芯-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3665",
-      "name": "貿聯-KY"
+      "name": "貿聯-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "3669",
-      "name": "圓展"
+      "name": "圓展",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3673",
-      "name": "TPK-KY"
+      "name": "TPK-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3679",
-      "name": "新至陞"
+      "name": "新至陞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3686",
-      "name": "達能"
+      "name": "達能",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3694",
-      "name": "海華"
+      "name": "海華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3701",
-      "name": "大眾控"
+      "name": "大眾控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3702",
-      "name": "大聯大"
+      "name": "大聯大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "3703",
-      "name": "欣陸"
+      "name": "欣陸",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "3704",
-      "name": "合勤控"
+      "name": "合勤控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "3705",
-      "name": "永信"
+      "name": "永信",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "3706",
-      "name": "神達"
+      "name": "神達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3708",
-      "name": "上緯投控"
+      "name": "上緯投控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "3711",
-      "name": "日月光投控"
+      "name": "日月光投控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "3712",
-      "name": "永崴投控"
+      "name": "永崴投控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "3714",
-      "name": "富采"
+      "name": "富采",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "3715",
-      "name": "定穎投控"
+      "name": "定穎投控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "3716",
-      "name": "中化控股"
+      "name": "中化控股",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "3717",
-      "name": "聯嘉投控"
+      "name": "聯嘉投控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "4104",
-      "name": "佳醫"
+      "name": "佳醫",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4106",
-      "name": "雃博"
+      "name": "雃博",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4108",
-      "name": "懷特"
+      "name": "懷特",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4119",
-      "name": "旭富"
+      "name": "旭富",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4133",
-      "name": "亞諾法"
+      "name": "亞諾法",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4137",
-      "name": "麗豐-KY"
+      "name": "麗豐-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4142",
-      "name": "國光生"
+      "name": "國光生",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4148",
-      "name": "全宇生技-KY"
+      "name": "全宇生技-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4155",
-      "name": "訊映"
+      "name": "訊映",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4164",
-      "name": "承業醫"
+      "name": "承業醫",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4190",
-      "name": "佐登-KY"
+      "name": "佐登-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4306",
-      "name": "炎洲"
+      "name": "炎洲",
+      "type": "股票",
+      "market": "上市",
+      "industry": "塑膠工業"
     },
     {
       "id": "4414",
-      "name": "如興"
+      "name": "如興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "4426",
-      "name": "利勤"
+      "name": "利勤",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "4438",
-      "name": "廣越"
+      "name": "廣越",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "4439",
-      "name": "冠星-KY"
+      "name": "冠星-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "4440",
-      "name": "宜新實業"
+      "name": "宜新實業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "4441",
-      "name": "振大環球"
+      "name": "振大環球",
+      "type": "股票",
+      "market": "上市",
+      "industry": "紡織纖維"
     },
     {
       "id": "4526",
-      "name": "東台"
+      "name": "東台",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4532",
-      "name": "瑞智"
+      "name": "瑞智",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4536",
-      "name": "拓凱"
+      "name": "拓凱",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "4540",
-      "name": "全球傳動"
+      "name": "全球傳動",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4545",
-      "name": "銘鈺"
+      "name": "銘鈺",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "4551",
-      "name": "智伸科"
+      "name": "智伸科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "4552",
-      "name": "力達-KY"
+      "name": "力達-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4555",
-      "name": "氣立"
+      "name": "氣立",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4557",
-      "name": "永新-KY"
+      "name": "永新-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "4560",
-      "name": "強信-KY"
+      "name": "強信-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4562",
-      "name": "穎漢"
+      "name": "穎漢",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4564",
-      "name": "元翎"
+      "name": "元翎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4566",
-      "name": "時碩工業"
+      "name": "時碩工業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4569",
-      "name": "六方科-KY"
+      "name": "六方科-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "4571",
-      "name": "鈞興-KY"
+      "name": "鈞興-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4572",
-      "name": "駐龍"
+      "name": "駐龍",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4576",
-      "name": "大銀微系統"
+      "name": "大銀微系統",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4581",
-      "name": "光隆精密-KY"
+      "name": "光隆精密-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "4583",
-      "name": "台灣精銳"
+      "name": "台灣精銳",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "4585",
-      "name": "達明"
+      "name": "達明",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "4588",
-      "name": "玖鼎電力"
+      "name": "玖鼎電力",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "4720",
-      "name": "德淵"
+      "name": "德淵",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4722",
-      "name": "國精化"
+      "name": "國精化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4736",
-      "name": "泰博"
+      "name": "泰博",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4737",
-      "name": "華廣"
+      "name": "華廣",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4739",
-      "name": "康普"
+      "name": "康普",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4746",
-      "name": "台耀"
+      "name": "台耀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4755",
-      "name": "三福化"
+      "name": "三福化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4763",
-      "name": "材料*-KY"
+      "name": "材料*-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4764",
-      "name": "雙鍵"
+      "name": "雙鍵",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4766",
-      "name": "南寶"
+      "name": "南寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4770",
-      "name": "上品"
+      "name": "上品",
+      "type": "股票",
+      "market": "上市",
+      "industry": "化學工業"
     },
     {
       "id": "4771",
-      "name": "望隼"
+      "name": "望隼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "4807",
-      "name": "日成-KY"
+      "name": "日成-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "4904",
-      "name": "遠傳"
+      "name": "遠傳",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "4906",
-      "name": "正文"
+      "name": "正文",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "4912",
-      "name": "聯德控股-KY"
+      "name": "聯德控股-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "4915",
-      "name": "致伸"
+      "name": "致伸",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "4916",
-      "name": "事欣科"
+      "name": "事欣科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "4919",
-      "name": "新唐"
+      "name": "新唐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "4927",
-      "name": "泰鼎-KY"
+      "name": "泰鼎-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "4930",
-      "name": "燦星網"
+      "name": "燦星網",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "4934",
-      "name": "太極"
+      "name": "太極",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "4935",
-      "name": "茂林-KY"
+      "name": "茂林-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "4938",
-      "name": "和碩"
+      "name": "和碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "4942",
-      "name": "嘉彰"
+      "name": "嘉彰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "4943",
-      "name": "康控-KY"
+      "name": "康控-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "4949",
-      "name": "有成精密"
+      "name": "有成精密",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "4952",
-      "name": "凌通"
+      "name": "凌通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "4956",
-      "name": "光鋐"
+      "name": "光鋐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "4958",
-      "name": "臻鼎-KY"
+      "name": "臻鼎-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "4960",
-      "name": "誠美材"
+      "name": "誠美材",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "4961",
-      "name": "天鈺"
+      "name": "天鈺",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "4967",
-      "name": "十銓"
+      "name": "十銓",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "4968",
-      "name": "立積"
+      "name": "立積",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "4976",
-      "name": "佳凌"
+      "name": "佳凌",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "4977",
-      "name": "眾達-KY"
+      "name": "眾達-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "4989",
-      "name": "榮科"
+      "name": "榮科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "4994",
-      "name": "傳奇"
+      "name": "傳奇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "4999",
-      "name": "鑫禾"
+      "name": "鑫禾",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "5007",
-      "name": "三星"
+      "name": "三星",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "5203",
-      "name": "訊連"
+      "name": "訊連",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "5215",
-      "name": "科嘉-KY"
+      "name": "科嘉-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "5222",
-      "name": "全訊"
+      "name": "全訊",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "5225",
-      "name": "東科-KY"
+      "name": "東科-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "5234",
-      "name": "達興材料"
+      "name": "達興材料",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "5243",
-      "name": "乙盛-KY"
+      "name": "乙盛-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "5244",
-      "name": "弘凱"
+      "name": "弘凱",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "5258",
-      "name": "虹堡"
+      "name": "虹堡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "5269",
-      "name": "祥碩"
+      "name": "祥碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "5283",
-      "name": "禾聯碩"
+      "name": "禾聯碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電器電纜"
     },
     {
       "id": "5284",
-      "name": "jpp-KY"
+      "name": "jpp-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "5285",
-      "name": "界霖"
+      "name": "界霖",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "5288",
-      "name": "豐祥-KY"
+      "name": "豐祥-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "5292",
-      "name": "華懋"
+      "name": "華懋",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "5306",
-      "name": "桂盟"
+      "name": "桂盟",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "5388",
-      "name": "中磊"
+      "name": "中磊",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "5434",
-      "name": "崇越"
+      "name": "崇越",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "5469",
-      "name": "瀚宇博"
+      "name": "瀚宇博",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "5471",
-      "name": "松翰"
+      "name": "松翰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "5484",
-      "name": "慧友"
+      "name": "慧友",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "5515",
-      "name": "建國"
+      "name": "建國",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5519",
-      "name": "隆大"
+      "name": "隆大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5521",
-      "name": "工信"
+      "name": "工信",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5522",
-      "name": "遠雄"
+      "name": "遠雄",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5525",
-      "name": "順天"
+      "name": "順天",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5531",
-      "name": "鄉林"
+      "name": "鄉林",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5533",
-      "name": "皇鼎"
+      "name": "皇鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5534",
-      "name": "長虹"
+      "name": "長虹",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5538",
-      "name": "東明-KY"
+      "name": "東明-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     },
     {
       "id": "5546",
-      "name": "永固-KY"
+      "name": "永固-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "5607",
-      "name": "遠雄港"
+      "name": "遠雄港",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "5608",
-      "name": "四維航"
+      "name": "四維航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "5706",
-      "name": "鳳凰"
+      "name": "鳳凰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "5871",
-      "name": "中租-KY"
+      "name": "中租-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "5876",
-      "name": "上海商銀"
+      "name": "上海商銀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "5880",
-      "name": "合庫金"
+      "name": "合庫金",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "5906",
-      "name": "台南-KY"
+      "name": "台南-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "5907",
-      "name": "大洋-KY"
+      "name": "大洋-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "6005",
-      "name": "群益證"
+      "name": "群益證",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "6024",
-      "name": "群益期"
+      "name": "群益期",
+      "type": "股票",
+      "market": "上市",
+      "industry": "金融保險業"
     },
     {
       "id": "6108",
-      "name": "競國"
+      "name": "競國",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6112",
-      "name": "邁達特"
+      "name": "邁達特",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "6115",
-      "name": "鎰勝"
+      "name": "鎰勝",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6116",
-      "name": "彩晶"
+      "name": "彩晶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6117",
-      "name": "迎廣"
+      "name": "迎廣",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6120",
-      "name": "達運"
+      "name": "達運",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6128",
-      "name": "上福"
+      "name": "上福",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6133",
-      "name": "金橋"
+      "name": "金橋",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6136",
-      "name": "富爾特"
+      "name": "富爾特",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6139",
-      "name": "亞翔"
+      "name": "亞翔",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6141",
-      "name": "柏承"
+      "name": "柏承",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6142",
-      "name": "友勁"
+      "name": "友勁",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6152",
-      "name": "百一"
+      "name": "百一",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6153",
-      "name": "嘉聯益"
+      "name": "嘉聯益",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6155",
-      "name": "鈞寶"
+      "name": "鈞寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6164",
-      "name": "華興"
+      "name": "華興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6165",
-      "name": "浪凡"
+      "name": "浪凡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "6166",
-      "name": "凌華"
+      "name": "凌華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6168",
-      "name": "宏齊"
+      "name": "宏齊",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6176",
-      "name": "瑞儀"
+      "name": "瑞儀",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6177",
-      "name": "達麗"
+      "name": "達麗",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "6183",
-      "name": "關貿"
+      "name": "關貿",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "6184",
-      "name": "大豐電"
+      "name": "大豐電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6189",
-      "name": "豐藝"
+      "name": "豐藝",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "6191",
-      "name": "精成科"
+      "name": "精成科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6192",
-      "name": "巨路"
+      "name": "巨路",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6196",
-      "name": "帆宣"
+      "name": "帆宣",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6197",
-      "name": "佳必琪"
+      "name": "佳必琪",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6201",
-      "name": "亞弘電"
+      "name": "亞弘電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6202",
-      "name": "盛群"
+      "name": "盛群",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6205",
-      "name": "詮欣"
+      "name": "詮欣",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6206",
-      "name": "飛捷"
+      "name": "飛捷",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6209",
-      "name": "今國光"
+      "name": "今國光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6213",
-      "name": "聯茂"
+      "name": "聯茂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6214",
-      "name": "精誠"
+      "name": "精誠",
+      "type": "股票",
+      "market": "上市",
+      "industry": "資訊服務業"
     },
     {
       "id": "6215",
-      "name": "和椿"
+      "name": "和椿",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6216",
-      "name": "居易"
+      "name": "居易",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6224",
-      "name": "聚鼎"
+      "name": "聚鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6225",
-      "name": "天瀚"
+      "name": "天瀚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6226",
-      "name": "光鼎"
+      "name": "光鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6230",
-      "name": "尼得科超眾"
+      "name": "尼得科超眾",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6235",
-      "name": "華孚"
+      "name": "華孚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6239",
-      "name": "力成"
+      "name": "力成",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6243",
-      "name": "迅杰"
+      "name": "迅杰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6257",
-      "name": "矽格"
+      "name": "矽格",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6269",
-      "name": "台郡"
+      "name": "台郡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6271",
-      "name": "同欣電"
+      "name": "同欣電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6272",
-      "name": "驊陞"
+      "name": "驊陞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6277",
-      "name": "宏正"
+      "name": "宏正",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6278",
-      "name": "台表科"
+      "name": "台表科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6281",
-      "name": "全國電"
+      "name": "全國電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "6282",
-      "name": "康舒"
+      "name": "康舒",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6283",
-      "name": "淳安"
+      "name": "淳安",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6285",
-      "name": "啟��"
+      "name": "啟��",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6405",
-      "name": "悅城"
+      "name": "悅城",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6409",
-      "name": "旭隼"
+      "name": "旭隼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6412",
-      "name": "群電"
+      "name": "群電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6414",
-      "name": "樺漢"
+      "name": "樺漢",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6415",
-      "name": "矽力*-KY"
+      "name": "矽力*-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6416",
-      "name": "瑞祺電通"
+      "name": "瑞祺電通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6426",
-      "name": "統新"
+      "name": "統新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6431",
-      "name": "光麗-KY"
+      "name": "光麗-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6438",
-      "name": "迅得"
+      "name": "迅得",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6442",
-      "name": "光聖"
+      "name": "光聖",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6443",
-      "name": "元晶"
+      "name": "元晶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6446",
-      "name": "藥華藥"
+      "name": "藥華藥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6449",
-      "name": "鈺邦"
+      "name": "鈺邦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6451",
-      "name": "訊芯-KY"
+      "name": "訊芯-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6456",
-      "name": "GIS-KY"
+      "name": "GIS-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6464",
-      "name": "台數科"
+      "name": "台數科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6472",
-      "name": "保瑞"
+      "name": "保瑞",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6477",
-      "name": "安集"
+      "name": "安集",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6491",
-      "name": "晶碩"
+      "name": "晶碩",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6504",
-      "name": "南六"
+      "name": "南六",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6505",
-      "name": "台塑化"
+      "name": "台塑化",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "6515",
-      "name": "穎崴"
+      "name": "穎崴",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6525",
-      "name": "捷敏-KY"
+      "name": "捷敏-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6526",
-      "name": "達發"
+      "name": "達發",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6531",
-      "name": "愛普*"
+      "name": "愛普*",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6533",
-      "name": "晶心科"
+      "name": "晶心科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6541",
-      "name": "泰福-KY"
+      "name": "泰福-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6550",
-      "name": "北極星藥業-KY"
+      "name": "北極星藥業-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6552",
-      "name": "易華電"
+      "name": "易華電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6558",
-      "name": "興能高"
+      "name": "興能高",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6573",
-      "name": "虹揚-KY"
+      "name": "虹揚-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6579",
-      "name": "研揚"
+      "name": "研揚",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6581",
-      "name": "鋼聯"
+      "name": "鋼聯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6582",
-      "name": "申豐"
+      "name": "申豐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "橡膠工業"
     },
     {
       "id": "6585",
-      "name": "鼎基"
+      "name": "鼎基",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6589",
-      "name": "台康生技"
+      "name": "台康生技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6591",
-      "name": "動力-KY"
+      "name": "動力-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6592",
-      "name": "和潤企業"
+      "name": "和潤企業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6598",
-      "name": "ABC-KY"
+      "name": "ABC-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6605",
-      "name": "帝寶"
+      "name": "帝寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "6606",
-      "name": "建德工業"
+      "name": "建德工業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "6614",
-      "name": "資拓宏宇"
+      "name": "資拓宏宇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "6625",
-      "name": "必應"
+      "name": "必應",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6641",
-      "name": "基士德-KY"
+      "name": "基士德-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6655",
-      "name": "科定"
+      "name": "科定",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6657",
-      "name": "華安"
+      "name": "華安",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6658",
-      "name": "聯策"
+      "name": "聯策",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6666",
-      "name": "羅麗芬-KY"
+      "name": "羅麗芬-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6668",
-      "name": "中揚光"
+      "name": "中揚光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6669",
-      "name": "緯穎"
+      "name": "緯穎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6670",
-      "name": "復盛應用"
+      "name": "復盛應用",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "6671",
-      "name": "三能-KY"
+      "name": "三能-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "6672",
-      "name": "騰輝電子-KY"
+      "name": "騰輝電子-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6674",
-      "name": "鋐寶科技"
+      "name": "鋐寶科技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6689",
-      "name": "伊雲谷"
+      "name": "伊雲谷",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "6691",
-      "name": "洋基工程"
+      "name": "洋基工程",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6695",
-      "name": "芯鼎"
+      "name": "芯鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6698",
-      "name": "旭暉應材"
+      "name": "旭暉應材",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6706",
-      "name": "惠特"
+      "name": "惠特",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6715",
-      "name": "嘉基"
+      "name": "嘉基",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6719",
-      "name": "力智"
+      "name": "力智",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6722",
-      "name": "輝創"
+      "name": "輝創",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6742",
-      "name": "澤米"
+      "name": "澤米",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6743",
-      "name": "安普新"
+      "name": "安普新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6753",
-      "name": "龍德造船"
+      "name": "龍德造船",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "6754",
-      "name": "匯僑設計"
+      "name": "匯僑設計",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "6756",
-      "name": "威鋒電子"
+      "name": "威鋒電子",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6757",
-      "name": "台灣虎航"
+      "name": "台灣虎航",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "6768",
-      "name": "志強-KY"
+      "name": "志強-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "6770",
-      "name": "力積電"
+      "name": "力積電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6776",
-      "name": "展�眥篕�"
+      "name": "展�眥篕�",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "6781",
-      "name": "AES-KY"
+      "name": "AES-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6782",
-      "name": "視陽"
+      "name": "視陽",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6789",
-      "name": "采鈺"
+      "name": "采鈺",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6790",
-      "name": "永豐實"
+      "name": "永豐實",
+      "type": "股票",
+      "market": "上市",
+      "industry": "造紙工業"
     },
     {
       "id": "6792",
-      "name": "詠業"
+      "name": "詠業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6794",
-      "name": "向榮生技"
+      "name": "向榮生技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6796",
-      "name": "晉弘"
+      "name": "晉弘",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6799",
-      "name": "來頡"
+      "name": "來頡",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6805",
-      "name": "富世達"
+      "name": "富世達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6806",
-      "name": "森崴能源"
+      "name": "森崴能源",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6807",
-      "name": "峰源-KY"
+      "name": "峰源-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "6830",
-      "name": "汎銓"
+      "name": "汎銓",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "6831",
-      "name": "邁科"
+      "name": "邁科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6834",
-      "name": "天二科技"
+      "name": "天二科技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6835",
-      "name": "圓裕"
+      "name": "圓裕",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6838",
-      "name": "台新藥"
+      "name": "台新藥",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6861",
-      "name": "睿生光電"
+      "name": "睿生光電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6862",
-      "name": "三集瑞-KY"
+      "name": "三集瑞-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "6863",
-      "name": "永道-KY"
+      "name": "永道-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "6869",
-      "name": "雲豹能源"
+      "name": "雲豹能源",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6873",
-      "name": "泓德能源"
+      "name": "泓德能源",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6885",
-      "name": "全福生技"
+      "name": "全福生技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6887",
-      "name": "寶綠特-KY"
+      "name": "寶綠特-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6890",
-      "name": "來億-KY"
+      "name": "來億-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "6901",
-      "name": "鑽石投資"
+      "name": "鑽石投資",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6902",
-      "name": "GOGOLOOK"
+      "name": "GOGOLOOK",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "6906",
-      "name": "現觀科"
+      "name": "現觀科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "6909",
-      "name": "創控"
+      "name": "創控",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6914",
-      "name": "阜爾運通"
+      "name": "阜爾運通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6916",
-      "name": "華凌"
+      "name": "華凌",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "6918",
-      "name": "愛派司"
+      "name": "愛派司",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6919",
-      "name": "康霈*"
+      "name": "康霈*",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6923",
-      "name": "中台"
+      "name": "中台",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6928",
-      "name": "攸泰科技"
+      "name": "攸泰科技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6931",
-      "name": "青松健康"
+      "name": "青松健康",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6933",
-      "name": "AMAX-KY"
+      "name": "AMAX-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "6934",
-      "name": "心誠鎂"
+      "name": "心誠鎂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6936",
-      "name": "永鴻生技"
+      "name": "永鴻生技",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "6937",
-      "name": "天虹"
+      "name": "天虹",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6944",
-      "name": "兆聯實業"
+      "name": "兆聯實業",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "6952",
-      "name": "大武山"
+      "name": "大武山",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6957",
-      "name": "裕慶-KY"
+      "name": "裕慶-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6958",
-      "name": "日盛台駿"
+      "name": "日盛台駿",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "6962",
-      "name": "奕力-KY"
+      "name": "奕力-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "6965",
-      "name": "中傑-KY"
+      "name": "中傑-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "6994",
-      "name": "富威電力"
+      "name": "富威電力",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "7705",
-      "name": "三商餐飲"
+      "name": "三商餐飲",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "7711",
-      "name": "永擎"
+      "name": "永擎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "7721",
-      "name": "微程式"
+      "name": "微程式",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "7722",
-      "name": "LINEPAY"
+      "name": "LINEPAY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "7732",
-      "name": "金興精密"
+      "name": "金興精密",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "7736",
-      "name": "虎山"
+      "name": "虎山",
+      "type": "股票",
+      "market": "上市",
+      "industry": "汽車工業"
     },
     {
       "id": "7749",
-      "name": "意騰-KY"
+      "name": "意騰-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "7750",
-      "name": "新代"
+      "name": "新代",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "7765",
-      "name": "中華資安"
+      "name": "中華資安",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "7769",
-      "name": "鴻勁"
+      "name": "鴻勁",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "7780",
-      "name": "大研生醫*"
+      "name": "大研生醫*",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "7786",
-      "name": "東方風能"
+      "name": "東方風能",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "7788",
-      "name": "松川精密"
+      "name": "松川精密",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "7791",
-      "name": "皇家可口"
+      "name": "皇家可口",
+      "type": "股票",
+      "market": "上市",
+      "industry": "食品工業"
     },
     {
       "id": "7795",
-      "name": "長廣"
+      "name": "長廣",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "7799",
-      "name": "禾榮科"
+      "name": "禾榮科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "生技醫療業"
     },
     {
       "id": "8011",
-      "name": "台通"
+      "name": "台通",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "8016",
-      "name": "矽創"
+      "name": "矽創",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8021",
-      "name": "尖點"
+      "name": "尖點",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "8028",
-      "name": "昇陽半導體"
+      "name": "昇陽半導體",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8033",
-      "name": "雷虎"
+      "name": "雷虎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8039",
-      "name": "台虹"
+      "name": "台虹",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "8045",
-      "name": "達運光電"
+      "name": "達運光電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "8046",
-      "name": "南電"
+      "name": "南電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "8070",
-      "name": "長華*"
+      "name": "長華*",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "8072",
-      "name": "陞泰"
+      "name": "陞泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "8081",
-      "name": "致新"
+      "name": "致新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8101",
-      "name": "華冠"
+      "name": "華冠",
+      "type": "股票",
+      "market": "上市",
+      "industry": "通信網路業"
     },
     {
       "id": "8103",
-      "name": "瀚荃"
+      "name": "瀚荃",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "8104",
-      "name": "錸寶"
+      "name": "錸寶",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "8105",
-      "name": "凌巨"
+      "name": "凌巨",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "8110",
-      "name": "華東"
+      "name": "華東",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8112",
-      "name": "至上"
+      "name": "至上",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子通路業"
     },
     {
       "id": "8114",
-      "name": "振樺電"
+      "name": "振樺電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "8131",
-      "name": "福懋科"
+      "name": "福懋科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8150",
-      "name": "南茂"
+      "name": "南茂",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8163",
-      "name": "達方"
+      "name": "達方",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "8201",
-      "name": "無敵"
+      "name": "無敵",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "8210",
-      "name": "勤誠"
+      "name": "勤誠",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "8213",
-      "name": "志超"
+      "name": "志超",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "8215",
-      "name": "明基材"
+      "name": "明基材",
+      "type": "股票",
+      "market": "上市",
+      "industry": "光電業"
     },
     {
       "id": "8222",
-      "name": "寶一"
+      "name": "寶一",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "8249",
-      "name": "菱光"
+      "name": "菱光",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電子零組件業"
     },
     {
       "id": "8261",
-      "name": "富鼎"
+      "name": "富鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8271",
-      "name": "宇瞻"
+      "name": "宇瞻",
+      "type": "股票",
+      "market": "上市",
+      "industry": "半導體業"
     },
     {
       "id": "8341",
-      "name": "日友"
+      "name": "日友",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "8367",
-      "name": "建新國際"
+      "name": "建新國際",
+      "type": "股票",
+      "market": "上市",
+      "industry": "航運業"
     },
     {
       "id": "8374",
-      "name": "羅昇"
+      "name": "羅昇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "8404",
-      "name": "百和興業-KY"
+      "name": "百和興業-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8411",
-      "name": "福貞-KY"
+      "name": "福貞-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8422",
-      "name": "可寧衛*"
+      "name": "可寧衛*",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "8429",
-      "name": "金麗-KY"
+      "name": "金麗-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "8438",
-      "name": "昶昕"
+      "name": "昶昕",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "8442",
-      "name": "威宏-KY"
+      "name": "威宏-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8443",
-      "name": "阿瘦"
+      "name": "阿瘦",
+      "type": "股票",
+      "market": "上市",
+      "industry": "貿易百貨業"
     },
     {
       "id": "8454",
-      "name": "富邦媒"
+      "name": "富邦媒",
+      "type": "股票",
+      "market": "上市",
+      "industry": "數位雲端"
     },
     {
       "id": "8462",
-      "name": "柏文"
+      "name": "柏文",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "8463",
-      "name": "潤泰材"
+      "name": "潤泰材",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8464",
-      "name": "億豐"
+      "name": "億豐",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "8466",
-      "name": "美吉吉-KY"
+      "name": "美吉吉-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8467",
-      "name": "波力-KY"
+      "name": "波力-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "8473",
-      "name": "山林水"
+      "name": "山林水",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "8476",
-      "name": "台境*"
+      "name": "台境*",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "8478",
-      "name": "東哥遊艇"
+      "name": "東哥遊艇",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "8481",
-      "name": "政伸"
+      "name": "政伸",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8482",
-      "name": "商億-KY"
+      "name": "商億-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "8488",
-      "name": "吉源-KY"
+      "name": "吉源-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "8499",
-      "name": "鼎炫-KY"
+      "name": "鼎炫-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他電子業"
     },
     {
       "id": "8926",
-      "name": "台汽電"
+      "name": "台汽電",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "8940",
-      "name": "新天地"
+      "name": "新天地",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "8996",
-      "name": "高力"
+      "name": "高力",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電機機械"
     },
     {
       "id": "9802",
-      "name": "鈺齊-KY"
+      "name": "鈺齊-KY",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "9902",
-      "name": "台火"
+      "name": "台火",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9904",
-      "name": "寶成"
+      "name": "寶成",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "9905",
-      "name": "大華"
+      "name": "大華",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9906",
-      "name": "欣巴巴"
+      "name": "欣巴巴",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "9907",
-      "name": "統一實"
+      "name": "統一實",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9908",
-      "name": "大台北"
+      "name": "大台北",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "9910",
-      "name": "豐泰"
+      "name": "豐泰",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "9911",
-      "name": "櫻花"
+      "name": "櫻花",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "9912",
-      "name": "偉聯"
+      "name": "偉聯",
+      "type": "股票",
+      "market": "上市",
+      "industry": "電腦及週邊設備業"
     },
     {
       "id": "9914",
-      "name": "美利達"
+      "name": "美利達",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "9917",
-      "name": "中保科"
+      "name": "中保科",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9918",
-      "name": "欣天然"
+      "name": "欣天然",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "9919",
-      "name": "康那香"
+      "name": "康那香",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9921",
-      "name": "巨大"
+      "name": "巨大",
+      "type": "股票",
+      "market": "上市",
+      "industry": "運動休閒"
     },
     {
       "id": "9924",
-      "name": "福興"
+      "name": "福興",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "9925",
-      "name": "新保"
+      "name": "新保",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9926",
-      "name": "新海"
+      "name": "新海",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "9927",
-      "name": "泰銘"
+      "name": "泰銘",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9928",
-      "name": "中視"
+      "name": "中視",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9929",
-      "name": "秋雨"
+      "name": "秋雨",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9930",
-      "name": "中聯資源"
+      "name": "中聯資源",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "9931",
-      "name": "欣高"
+      "name": "欣高",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "9933",
-      "name": "中鼎"
+      "name": "中鼎",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9934",
-      "name": "成霖"
+      "name": "成霖",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "9935",
-      "name": "慶豐富"
+      "name": "慶豐富",
+      "type": "股票",
+      "market": "上市",
+      "industry": "居家生活"
     },
     {
       "id": "9937",
-      "name": "全國"
+      "name": "全國",
+      "type": "股票",
+      "market": "上市",
+      "industry": "油電燃氣業"
     },
     {
       "id": "9938",
-      "name": "百和"
+      "name": "百和",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9939",
-      "name": "宏全"
+      "name": "宏全",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9940",
-      "name": "信義"
+      "name": "信義",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9941",
-      "name": "裕融"
+      "name": "裕融",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9942",
-      "name": "茂順"
+      "name": "茂順",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9943",
-      "name": "好樂迪"
+      "name": "好樂迪",
+      "type": "股票",
+      "market": "上市",
+      "industry": "觀光餐旅"
     },
     {
       "id": "9944",
-      "name": "新麗"
+      "name": "新麗",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9945",
-      "name": "潤泰新"
+      "name": "潤泰新",
+      "type": "股票",
+      "market": "上市",
+      "industry": "其他業"
     },
     {
       "id": "9946",
-      "name": "三發地產"
+      "name": "三發地產",
+      "type": "股票",
+      "market": "上市",
+      "industry": "建材營造業"
     },
     {
       "id": "9955",
-      "name": "佳龍"
+      "name": "佳龍",
+      "type": "股票",
+      "market": "上市",
+      "industry": "綠能環保"
     },
     {
       "id": "9958",
-      "name": "世紀鋼"
+      "name": "世紀鋼",
+      "type": "股票",
+      "market": "上市",
+      "industry": "鋼鐵工業"
     }
   ]
 }


### PR DESCRIPTION
## Taiwan Stock List Sync

Auto-generated by [sync-tw-stocks](https://github.com/Egg-Village-Python-Workshop/egg-village-platform/actions/workflows/sync-tw-stocks.yml) workflow.

| 項目 | 數量 |
|------|------|
| 新增 | 0 筆 |
| 合計 | 1261 筆 |

**來源**: [台灣證交所 ISIN 有價證券清單](https://isin.twse.com.tw/isin/C_public.jsp?strMode=2)